### PR TITLE
Add multi-stage Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,37 @@
 # MAZLABZ Enterprise Terminal - Production Dockerfile
-# Optimized for Google Cloud Run deployment
+# Multi-stage build optimized for Cloud Run
 
+# --- build stage ---
+FROM node:20-slim AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# --- runtime stage ---
 FROM nginx:alpine
-
-# Set maintainer
 LABEL maintainer="jack.mazzini@mazlabz.com"
 LABEL description="MAZLABZ Enterprise Terminal Interface"
 LABEL version="1.0.0"
 
-# Copy the terminal application
-COPY index.html /usr/share/nginx/html/
+COPY --from=build /app/dist/ /usr/share/nginx/html/
 
-# Create custom nginx configuration for SPA
-RUN echo 'server {' > /etc/nginx/conf.d/default.conf && \
-    echo '    listen 8080;' >> /etc/nginx/conf.d/default.conf && \
-    echo '    server_name localhost;' >> /etc/nginx/conf.d/default.conf && \
-    echo '    root /usr/share/nginx/html;' >> /etc/nginx/conf.d/default.conf && \
-    echo '    index index.html;' >> /etc/nginx/conf.d/default.conf && \
-    echo '    location / {' >> /etc/nginx/conf.d/default.conf && \
-    echo '        try_files $uri $uri/ /index.html;' >> /etc/nginx/conf.d/default.conf && \
-    echo '    }' >> /etc/nginx/conf.d/default.conf && \
-    echo '    # Security headers' >> /etc/nginx/conf.d/default.conf && \
-    echo '    add_header X-Frame-Options "SAMEORIGIN" always;' >> /etc/nginx/conf.d/default.conf && \
-    echo '    add_header X-Content-Type-Options "nosniff" always;' >> /etc/nginx/conf.d/default.conf && \
-    echo '    add_header X-XSS-Protection "1; mode=block" always;' >> /etc/nginx/conf.d/default.conf && \
-    echo '    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;' >> /etc/nginx/conf.d/default.conf && \
-    echo '}' >> /etc/nginx/conf.d/default.conf
+# SPA routing config
+RUN echo 'server {' > /etc/nginx/conf.d/default.conf \
+ && echo '    listen 8080;' >> /etc/nginx/conf.d/default.conf \
+ && echo '    server_name localhost;' >> /etc/nginx/conf.d/default.conf \
+ && echo '    root /usr/share/nginx/html;' >> /etc/nginx/conf.d/default.conf \
+ && echo '    index index.html;' >> /etc/nginx/conf.d/default.conf \
+ && echo '    location / {' >> /etc/nginx/conf.d/default.conf \
+ && echo '        try_files $uri $uri/ /index.html;' >> /etc/nginx/conf.d/default.conf \
+ && echo '    }' >> /etc/nginx/conf.d/default.conf \
+ && echo '    # Security headers' >> /etc/nginx/conf.d/default.conf \
+ && echo '    add_header X-Frame-Options "SAMEORIGIN" always;' >> /etc/nginx/conf.d/default.conf \
+ && echo '    add_header X-Content-Type-Options "nosniff" always;' >> /etc/nginx/conf.d/default.conf \
+ && echo '    add_header X-XSS-Protection "1; mode=block" always;' >> /etc/nginx/conf.d/default.conf \
+ && echo '    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;' >> /etc/nginx/conf.d/default.conf \
+ && echo '}' >> /etc/nginx/conf.d/default.conf
 
-# Expose port 8080 (Cloud Run requirement)
 EXPOSE 8080
-
-# Start nginx
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- refactor Dockerfile to use a builder stage
- run `npm ci` and `npm run build`
- copy the compiled `dist/` directory into the nginx runtime image
- retain SPA routing config

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687f02ea8a38832c9d76e9d214984090