### PR TITLE
Enhance terminal system status

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -7,6 +7,7 @@ import path from 'path';
 import fs from 'fs';
 import { fileURLToPath } from 'url';
 import { uploadToGCS } from './uploadToGCS.js';
+import os from 'os';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -80,6 +81,12 @@ app.post("/api/research/microphone/permission", (req, res) => {
   const { sessionId, granted, timestamp } = req.body;
   micPermissions.push({ sessionId, granted, ts: timestamp });
   res.json({ status: "logged" });
+});
+
+app.get('/api/system/status', (req, res) => {
+  const cpu = os.loadavg()[0] ? Math.min(100, Math.round((os.loadavg()[0] / os.cpus().length) * 100)) : 0;
+  const memory = Math.round(((os.totalmem() - os.freemem()) / os.totalmem()) * 100);
+  res.json({ cpu, memory, uptime: os.uptime() });
 });
 
 const PORT = process.env.PORT || 8080;

--- a/src/components/AdminDashboard.jsx
+++ b/src/components/AdminDashboard.jsx
@@ -12,6 +12,7 @@ const AdminDashboard = ({ onClose, files, metadata, status }) => (
       <ul>
         <li>CPU: {status.cpu}%</li>
         <li>Memory: {status.memory}%</li>
+        <li>Uptime: {Math.floor(status.uptime / 60)}m</li>
         <li>Uploaded Files: {status.files}</li>
       </ul>
       <h3>Uploaded Files</h3>

--- a/src/hooks/useSystemStatus.js
+++ b/src/hooks/useSystemStatus.js
@@ -1,16 +1,26 @@
 import { useState, useEffect } from 'react'
 
 export default function useSystemStatus(fileCount) {
-  const [status, setStatus] = useState({ cpu: 0, memory: 0, files: 0 })
+  const [status, setStatus] = useState({ cpu: 0, memory: 0, files: 0, uptime: 0 })
 
   useEffect(() => {
-    const interval = setInterval(() => {
-      setStatus({
-        cpu: Math.floor(Math.random() * 40) + 10,
-        memory: Math.floor(Math.random() * 20) + 40,
-        files: fileCount
-      })
-    }, 5000)
+    const fetchStatus = async () => {
+      try {
+        const res = await fetch('/api/system/status')
+        if (res.ok) {
+          const data = await res.json()
+          setStatus({
+            cpu: data.cpu,
+            memory: data.memory,
+            uptime: data.uptime,
+            files: fileCount
+          })
+        }
+      } catch {}
+    }
+
+    fetchStatus()
+    const interval = setInterval(fetchStatus, 5000)
     return () => clearInterval(interval)
   }, [fileCount])
 


### PR DESCRIPTION
## Summary
- add `/api/system/status` endpoint in Express server
- fetch real system metrics in `useSystemStatus`
- display uptime in `AdminDashboard`

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6882d37748dc832c8c7bb1bb1aa9e5e9