### PR TITLE
Add Manus landing page

### DIFF
--- a/src/ManusSite.css
+++ b/src/ManusSite.css
@@ -1,0 +1,53 @@
+.manus-container {
+  font-family: system-ui, sans-serif;
+  color: #222;
+  line-height: 1.6;
+}
+
+.manus-hero {
+  min-height: 60vh;
+  padding: 4rem 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #eef2ff, #dbeafe);
+  text-align: center;
+}
+
+.manus-hero h1 {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+}
+
+.manus-hero p {
+  max-width: 600px;
+  margin-bottom: 2rem;
+}
+
+.cta-button {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  background: #2563eb;
+  color: #fff;
+  border-radius: 0.375rem;
+  text-decoration: none;
+}
+
+.manus-section {
+  padding: 4rem 1rem;
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.features {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 2rem;
+  margin-top: 2rem;
+}
+
+.feature h3 {
+  margin-bottom: 0.5rem;
+  font-size: 1.25rem;
+}

--- a/src/ManusSite.jsx
+++ b/src/ManusSite.jsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import './ManusSite.css'
+
+const ManusSite = () => {
+  return (
+    <div className="manus-container">
+      <header className="manus-hero">
+        <h1>Manus</h1>
+        <p>Adaptive knowledge engine for modern applications.</p>
+        <a href="#contact" className="cta-button">Get in Touch</a>
+      </header>
+      <section className="manus-section">
+        <h2>Why Manus?</h2>
+        <p>
+          Manus integrates data, reasoning and user intent to deliver precise answers and
+          streamlined automation.
+        </p>
+        <div className="features">
+          <div className="feature">
+            <h3>Realtime Insights</h3>
+            <p>Connect live data sources and surface actionable context in milliseconds.</p>
+          </div>
+          <div className="feature">
+            <h3>Secure by Design</h3>
+            <p>Built with enterprise security primitives for safe deployment.</p>
+          </div>
+          <div className="feature">
+            <h3>Flexible APIs</h3>
+            <p>Embed Manus in existing stacks or build new experiences on top.</p>
+          </div>
+        </div>
+      </section>
+      <section className="manus-section" id="contact">
+        <h2>Contact</h2>
+        <p>Email <a href="mailto:hello@manus.im">hello@manus.im</a> to request early access.</p>
+      </section>
+    </div>
+  )
+}
+
+export default ManusSite

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,9 +1,13 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
+import ManusSite from './ManusSite.jsx'
+
+const path = window.location.pathname
+const RootComponent = path.startsWith('/manus') ? ManusSite : App
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <RootComponent />
   </React.StrictMode>
 )


### PR DESCRIPTION
## Summary
- render new Manus landing experience when visiting `/manus`
- add ManusSite component with hero, features and contact sections
- style Manus landing page with responsive CSS

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68906a1b996c8332a9d6a4c8767fe8c7