### PR TITLE
feat: add pigeon protocol prototype

### DIFF
--- a/server/database.js
+++ b/server/database.js
@@ -55,6 +55,15 @@ export async function connect() {
         created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
         FOREIGN KEY (session_id) REFERENCES sessions (id)
     );
+
+    CREATE TABLE IF NOT EXISTS pigeon_messages (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT,
+        recipient TEXT,
+        message TEXT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (session_id) REFERENCES sessions (id)
+    );
   `);
 
   return db;
@@ -86,6 +95,16 @@ export async function addLead({ sessionId, name, email, company, projectType, bu
         'INSERT INTO leads (session_id, name, email, company, project_type, budget) VALUES (?, ?, ?, ?, ?, ?)',
         sessionId, name, email, company, projectType, budget
     );
+}
+
+export async function addPigeonMessage({ sessionId, recipient, message }) {
+  const db = await connect();
+  await db.run(
+    'INSERT INTO pigeon_messages (session_id, recipient, message) VALUES (?, ?, ?)',
+    sessionId,
+    recipient,
+    message
+  );
 }
 
 

--- a/server/index.js
+++ b/server/index.js
@@ -10,7 +10,7 @@ import { uploadToGCS } from './uploadToGCS.js';
 import * as db from './database.js';
 
 // Import required database functions
-const { storeFileMetadata, addSession, logCommand } = db;
+const { storeFileMetadata, addSession, logCommand, addPigeonMessage } = db;
 import StepdaddyHub from './stepdaddy.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -172,6 +172,20 @@ app.post('/api/leads', async (req, res) => {
     } catch (err) {
         console.error('Failed to save lead:', err);
         res.status(500).json({ error: 'failed to save lead' });
+    }
+});
+
+app.post('/api/pigeon/send', async (req, res) => {
+    const { sessionId, recipient, message } = req.body;
+    if (!sessionId || !recipient || !message) {
+        return res.status(400).json({ error: 'sessionId, recipient, and message are required' });
+    }
+    try {
+        await addPigeonMessage({ sessionId, recipient, message });
+        res.json({ status: 'delivered' });
+    } catch (err) {
+        console.error('Failed to store pigeon message:', err);
+        res.status(500).json({ error: 'failed to deliver pigeon message' });
     }
 });
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import ROICalculator from './components/ROICalculator'
 import PaymentProcessor from './components/PaymentProcessor'
 import DocumentUploader from './components/DocumentUploader'
 import Stepdaddy from './components/Stepdaddy'
+import PigeonProtocol from './components/PigeonProtocol'
 import useMicRecorder from './hooks/useMicRecorder'
 import useCamSnapshot from './hooks/useCamSnapshot'
 
@@ -23,6 +24,7 @@ const App = () => {
   const [showPaymentProcessor, setShowPaymentProcessor] = useState(false)
   const [showDocumentUploader, setShowDocumentUploader] = useState(false)
   const [showStepdaddy, setShowStepdaddy] = useState(false)
+  const [showPigeonProtocol, setShowPigeonProtocol] = useState(false)
   const [projectData, setProjectData] = useState(null)
   const inputRef = useRef(null)
   const terminalRef = useRef(null)
@@ -122,6 +124,7 @@ const App = () => {
       '  health       - API health check',
       '  download <id>- Download a specific file by ID',
       '  delete <id>  - Delete a specific file by ID',
+      '  pigeon      - Alternate pigeon protocol',
       '  schedule     - Book executive meeting',
       '',
       'SMART HOME INTEGRATION (STEPDADDY):',
@@ -387,6 +390,19 @@ const App = () => {
         'Requesting browser file access permissions...',
         'Scanning for recent documents (PDF, DOC, DOCX, TXT)...',
         'Enterprise-grade encryption enabled.',
+        ''
+      ]
+    },
+    pigeon: () => {
+      fetch(`${API_BASE}/api/research/behavioral/track`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId, command: 'pigeon' })
+      }).catch(() => {})
+      setShowPigeonProtocol(true)
+      return [
+        'INITIALIZING ALTERNATE PIGEON PROTOCOL...',
+        'Preparing carrier pigeons for dispatch...',
         ''
       ]
     },
@@ -921,14 +937,17 @@ const App = () => {
         <DocumentUploader sessionId={sessionId} onClose={() => setShowDocumentUploader(false)} onUpload={handleDocumentUpload} />
       )}
       {showStepdaddy && (
-        <Stepdaddy 
-          onClose={() => setShowStepdaddy(false)} 
+        <Stepdaddy
+          onClose={() => setShowStepdaddy(false)}
           onOutput={(messages) => {
             messages.forEach(message => {
               setOutput(prev => [...prev, { type: 'success', content: message }])
             })
-          }} 
+          }}
         />
+      )}
+      {showPigeonProtocol && (
+        <PigeonProtocol onClose={() => setShowPigeonProtocol(false)} sessionId={sessionId} />
       )}
     </div>
   )

--- a/src/components/PigeonProtocol.css
+++ b/src/components/PigeonProtocol.css
@@ -1,0 +1,68 @@
+.pigeon-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.pigeon-content {
+  background: #1a1a1a;
+  border: 2px solid #0f0;
+  padding: 20px;
+  color: #0f0;
+  width: 400px;
+  max-width: 90%;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  color: #0f0;
+  font-size: 24px;
+  cursor: pointer;
+}
+
+.pigeon-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.pigeon-form input,
+.pigeon-form textarea {
+  background: #000;
+  border: 1px solid #0f0;
+  color: #0f0;
+  padding: 8px;
+}
+
+.pigeon-form button {
+  background: #0f0;
+  color: #000;
+  padding: 8px;
+  cursor: pointer;
+}
+
+.success {
+  color: #0f0;
+  margin-top: 10px;
+}
+
+.error {
+  color: #f00;
+  margin-top: 10px;
+}
+

--- a/src/components/PigeonProtocol.jsx
+++ b/src/components/PigeonProtocol.jsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react'
+import './PigeonProtocol.css'
+
+const API_BASE = import.meta.env.VITE_API_BASE || ''
+
+const PigeonProtocol = ({ onClose, sessionId }) => {
+  const [recipient, setRecipient] = useState('')
+  const [message, setMessage] = useState('')
+  const [status, setStatus] = useState(null)
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setStatus(null)
+    try {
+      const res = await fetch(`${API_BASE}/api/pigeon/send`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sessionId, recipient, message })
+      })
+      const data = await res.json()
+      if (res.ok) {
+        setStatus('delivered')
+        setRecipient('')
+        setMessage('')
+      } else {
+        setStatus(data.error || 'failed')
+      }
+    } catch (err) {
+      console.error('Failed to send pigeon message:', err)
+      setStatus('failed')
+    }
+  }
+
+  return (
+    <div className="pigeon-modal">
+      <div className="pigeon-content">
+        <div className="modal-header">
+          <h2>🕊️ Alternate Pigeon Protocol</h2>
+          <button className="close-btn" onClick={onClose}>&times;</button>
+        </div>
+        <p>Transmit secure messages using our experimental carrier pigeon network.</p>
+        <form onSubmit={handleSubmit} className="pigeon-form">
+          <input
+            type="text"
+            placeholder="Recipient"
+            value={recipient}
+            onChange={(e) => setRecipient(e.target.value)}
+            required
+          />
+          <textarea
+            placeholder="Message"
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            rows="4"
+            required
+          />
+          <button type="submit">Send Pigeon</button>
+        </form>
+        {status === 'delivered' && (
+          <p className="success">✅ Message dispatched via pigeon</p>
+        )}
+        {status && status !== 'delivered' && (
+          <p className="error">❌ {status}</p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default PigeonProtocol
+

--- a/src/components/PigeonProtocol.jsx
+++ b/src/components/PigeonProtocol.jsx
@@ -26,7 +26,7 @@ const PigeonProtocol = ({ onClose, sessionId }) => {
         setStatus(data.error || 'failed')
       }
     } catch (err) {
-      console.error('Failed to send pigeon message:', err)
+      console.error('Failed to send pigeon message')
       setStatus('failed')
     }
   }


### PR DESCRIPTION
## Summary
- add interactive PigeonProtocol modal for experimental pigeon messaging
- expose `pigeon` terminal command to launch protocol and log usage
- support pigeon messages with new API endpoint and database table

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a692c9e0ec8332940a6e6803d21b98